### PR TITLE
Add target DPI selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A Python application for image upscaling with a graphical user interface using R
 - Preview original and upscaled images.
 - Save upscaled images in various formats (PNG, TIFF, JPEG).
 - Displays image dimensions and DPI.
+• User-selectable target DPI written into the saved file’s metadata.
 
 ## Setup
 


### PR DESCRIPTION
## Summary
- add target DPI entry field and validation to the GUI
- apply target DPI when upscaling and saving images
- show chosen DPI in upscaled image info
- document the new feature in the README

## Testing
- `python -m py_compile gui.py utils.py upscaler.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_686806ccfa90832a95298dfc6e456d3a